### PR TITLE
Handle storage and event submission errors

### DIFF
--- a/fix_events_rls.sql
+++ b/fix_events_rls.sql
@@ -1,0 +1,54 @@
+-- Fix RLS for events so organizers can insert/update/select their own events
+
+-- Ensure RLS is enabled
+ALTER TABLE public.events ENABLE ROW LEVEL SECURITY;
+
+-- Public can view approved events
+DROP POLICY IF EXISTS "Public can view approved events" ON public.events;
+CREATE POLICY "Public can view approved events" ON public.events
+  FOR SELECT
+  USING (status = 'approved');
+
+-- Organizers can view their own events (supports either organizer_id or created_by)
+DROP POLICY IF EXISTS "Organizers can select own events" ON public.events;
+CREATE POLICY "Organizers can select own events" ON public.events
+  FOR SELECT
+  USING (COALESCE(organizer_id, created_by) = auth.uid());
+
+-- Organizers can create their own events
+DROP POLICY IF EXISTS "Organizers can insert events" ON public.events;
+CREATE POLICY "Organizers can insert events" ON public.events
+  FOR INSERT
+  WITH CHECK (COALESCE(organizer_id, created_by) = auth.uid());
+
+-- Organizers can update their own events
+DROP POLICY IF EXISTS "Organizers can update events" ON public.events;
+CREATE POLICY "Organizers can update events" ON public.events
+  FOR UPDATE
+  USING (COALESCE(organizer_id, created_by) = auth.uid());
+
+-- Organizers can delete their own events (optional)
+DROP POLICY IF EXISTS "Organizers can delete events" ON public.events;
+CREATE POLICY "Organizers can delete events" ON public.events
+  FOR DELETE
+  USING (COALESCE(organizer_id, created_by) = auth.uid());
+
+-- Ticket types: allow organizers to manage ticket types of their events
+DROP POLICY IF EXISTS "Organizers can manage their ticket types" ON public.event_ticket_types;
+CREATE POLICY "Organizers can manage their ticket types" ON public.event_ticket_types
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.events e
+      WHERE e.id = event_ticket_types.event_id
+        AND COALESCE(e.organizer_id, e.created_by) = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.events e
+      WHERE e.id = event_ticket_types.event_id
+        AND COALESCE(e.organizer_id, e.created_by) = auth.uid()
+    )
+  );
+

--- a/fix_storage_policies.sql
+++ b/fix_storage_policies.sql
@@ -1,0 +1,38 @@
+-- Storage: ensure bucket exists and policies allow public read + authenticated write
+
+-- Create bucket if it does not exist (run once via SQL editor if permitted)
+-- Note: On hosted Supabase, bucket creation is via API/Studio. This DDL is for self-hosted.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM storage.buckets WHERE id = 'event_banners'
+  ) THEN
+    INSERT INTO storage.buckets (id, name, public)
+    VALUES ('event_banners', 'event_banners', true);
+  END IF;
+END $$;
+
+-- Public read access to files in the bucket
+DROP POLICY IF EXISTS "Public read for event_banners" ON storage.objects;
+CREATE POLICY "Public read for event_banners" ON storage.objects
+  FOR SELECT
+  USING (
+    bucket_id = 'event_banners'
+  );
+
+-- Authenticated users can upload to the bucket
+DROP POLICY IF EXISTS "Authenticated upload to event_banners" ON storage.objects;
+CREATE POLICY "Authenticated upload to event_banners" ON storage.objects
+  FOR INSERT
+  WITH CHECK (
+    bucket_id = 'event_banners' AND auth.role() = 'authenticated'
+  );
+
+-- Authenticated users can update their own files (optional tighten by owner)
+DROP POLICY IF EXISTS "Authenticated update event_banners" ON storage.objects;
+CREATE POLICY "Authenticated update event_banners" ON storage.objects
+  FOR UPDATE
+  USING (
+    bucket_id = 'event_banners' AND auth.role() = 'authenticated'
+  );
+

--- a/src/components/EventFormModal.tsx
+++ b/src/components/EventFormModal.tsx
@@ -275,25 +275,8 @@ const EventFormModal: React.FC<EventFormModalProps> = ({ isOpen, onClose, onEven
       
       console.log('🔄 Iniciando upload:', fileName);
 
-      // Verificar se o bucket existe
-      const { data: buckets, error: bucketsError } = await supabase.storage.listBuckets();
-      console.log('📦 Buckets disponíveis:', buckets);
-      
-      if (bucketsError) {
-        console.error('❌ Erro ao listar buckets:', bucketsError);
-      }
-
-      // Tentar criar o bucket se não existir
-      const { data: bucketData, error: bucketError } = await supabase.storage
-        .createBucket('event_banners', {
-          public: true,
-          allowedMimeTypes: ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'],
-          fileSizeLimit: 5242880 // 5MB
-        });
-
-      if (bucketError && !bucketError.message.includes('already exists')) {
-        console.error('❌ Erro ao criar bucket:', bucketError);
-      }
+      // Assume o bucket 'event_banners' já existe (criado via painel/CLI).
+      // Upload direto; se o bucket não existir, o upload abaixo retornará erro informativo.
 
       // Upload para Supabase Storage
       const { data, error } = await supabase.storage


### PR DESCRIPTION
Removes client-side storage bucket creation and adds SQL scripts to fix Supabase RLS policies for events and storage.

The client-side bucket creation was causing a 400 RLS error because it's an administrative task. The 403 error on event insertion was due to insufficient RLS policies on the `events` table. This PR fixes both by moving bucket creation/policy definition to SQL scripts and updating event RLS to allow authenticated users to manage their own events.

---
<a href="https://cursor.com/background-agent?bcId=bc-afe41c0f-a70d-401c-85ef-9c2f55889050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-afe41c0f-a70d-401c-85ef-9c2f55889050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

