### PR TITLE
Fetch event description for display

### DIFF
--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -17,6 +17,7 @@ interface Event {
   id: string;
   title: string;
   description: string;
+  eventPolicy: string;
   date: string;
   time: string;
   location: string;
@@ -72,6 +73,7 @@ interface SupabaseEvent {
   id: string;
   title: string;
   description: string;
+  descricion?: string;
   date: string;
   time: string;
   location: string;
@@ -280,6 +282,7 @@ const EventPage = () => {
           id,
           title,
           description,
+          descricion,
           start_date,
           end_date,
           location,
@@ -376,6 +379,7 @@ const EventPage = () => {
         id: eventData.id,
         title: eventData.title,
         description: eventData.description || 'Descrição não disponível',
+        eventPolicy: eventData.descricion || eventData.description || 'Não informado',
         date: eventData.start_date?.split('T')[0] || '',
         time: eventData.start_date?.split('T')[1]?.substring(0, 5) || '',
         location: eventData.location_name || eventData.location || 'Local não informado',
@@ -593,6 +597,11 @@ const EventPage = () => {
                   </li>
                 ))}
               </ul>
+            </div>
+
+            <div className="bg-gray-50 p-4 rounded-lg">
+              <h3 className="font-semibold text-lg mb-3">POLÍTICA DE EVENTOS</h3>
+              <p className="text-sm whitespace-pre-wrap">{event?.eventPolicy || 'Não informado'}</p>
             </div>
             
             <div className="bg-gray-50 p-4 rounded-lg">


### PR DESCRIPTION
Add a 'POLÍTICA DE EVENTOS' section to the event page to display event policy fetched from the `events.descricion` column.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe31ff8f-5d22-4fe7-a553-f69897bdb7d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe31ff8f-5d22-4fe7-a553-f69897bdb7d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

